### PR TITLE
Fixed error in model.forecast method. Fixes #8

### DIFF
--- a/fireTS/models.py
+++ b/fireTS/models.py
@@ -1,6 +1,6 @@
 from fireTS.core import GeneralAutoRegressor
 from sklearn.utils.validation import check_X_y, check_array
-from sklearn.metrics.regression import r2_score, mean_squared_error
+from sklearn.metrics import r2_score, mean_squared_error
 import numpy as np
 from collections import deque
 
@@ -132,7 +132,7 @@ class NARX(GeneralAutoRegressor):
 
         auto_regressor = deque(y[:(-1 - self.auto_order):-1])
         exog_regressors = [
-                deque(X[(-1 - d):(-1 - q):-1, i])
+                deque(X[(-1 - d):(-1 - d - q):-1, i])
                 for i, (d, q) in enumerate(zip(self.exog_delay, self.exog_order))
                 ]
         cur_step = 0

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -29,5 +29,29 @@ def test_forecast_and_predict_consistency():
     np.testing.assert_almost_equal(ypred[-1], yforecast[-1])
 
 
+def test_forecast_exog_delay():
+    np.random.seed(0)
+    x = np.random.randn(10, 1)
+    y = np.random.randn(10)
+
+    # delay 0
+    mdl = NARX(LinearRegression(), auto_order=2, exog_order=[2], exog_delay=[0])
+    mdl.fit(x, y)
+    yforecast = mdl.forecast(x[:-1, :], y[:-1], step=1)
+    np.testing.assert_almost_equal(yforecast, [-0.50000582])
+
+    # delay 1
+    mdl = NARX(LinearRegression(), auto_order=2, exog_order=[2], exog_delay=[1])
+    mdl.fit(x, y)
+    yforecast = mdl.forecast(x[:-1, :], y[:-1], step=1)
+    np.testing.assert_almost_equal(yforecast, [-0.53345719])
+
+    # delay 2
+    mdl = NARX(LinearRegression(), auto_order=2, exog_order=[2], exog_delay=[2])
+    mdl.fit(x, y)
+    yforecast = mdl.forecast(x[:-1, :], y[:-1], step=1)
+    np.testing.assert_almost_equal(yforecast, [-0.61640028])
+
 if __name__ == '__main__':
     test_forecast_and_predict_consistency()
+    test_forecast_exog_delay()


### PR DESCRIPTION
changed line 135 in models:
`deque(X[(-1 - d):(-1 - q):-1, i])`
to the following:
`deque(X[(-1 - d):(-1 - d - q):-1, i])`

Also updated the import of sklearn metrics; sklearn.metrics.regression is deprecated.